### PR TITLE
Don't fail CI if the commit doesn't change the generated HTML.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,5 +48,5 @@ jobs:
           cd UMN-Kernel-Object.github.io
           rm -rf docs/.buildinfo docs/_sources docs/.doctrees
           git add docs
-          git commit -m "Documentation Update `date`"
+          git commit --allow-empty -m "Documentation Update `date`"
           git push origin main


### PR DESCRIPTION
I think this is why https://github.com/UMN-Kernel-Object/documentation/actions/runs/10823131479/job/30028127560 failed